### PR TITLE
Update createStore.ts

### DIFF
--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -184,7 +184,7 @@ export default function createStore<
       if (isDispatching) {
         throw new Error(
           'You may not unsubscribe from a store listener while the reducer is executing. ' +
-            'See https://redux.js.org/api-reference/store#subscribelistener for more details.'
+            'See https://redux.js.org/api/store#subscribelistener for more details.'
         )
       }
 


### PR DESCRIPTION
Replaced the broken link, "https://redux.js.org/api-reference/store#subscribelistener" link in the error message, by the correct link which is "https://redux.js.org/api/store#subscribelistener"

---
name: "\U0001F4DD Documentation Fix"
about: Fixing a problem in an existing docs page
---

## Checklist

- [ ] Is there an existing issue for this PR?
  - _https://github.com/reduxjs/redux/issues/3725_
- [ ] Have the files been linted and formatted?
 - Yes
## What docs page needs to be fixed?

- **Section**: NA
- **Page**: NA

## What is the problem?
A broken link is being displayed in the error message
## What changes does this PR make to fix the problem?
The PR changes the broken link to the correct one.